### PR TITLE
Fix: library is not working or outdated

### DIFF
--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.h
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.h
@@ -27,12 +27,11 @@
 
 typedef void(^HTTPRequestSuccessCompletion)(NSString *redirectLocation, NSData *xmlData);
 typedef void(^HTTPRequestFailureCompletion)(NSError *error);
+typedef void(^HTTPRecieveDataBlock)(NSData *data);
 
 @interface EWSHttpRequest : NSObject
 
--(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock;
-
--(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock;
+-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock finishLoading:(void (^)(NSData *data))finishLoadingBlock error:(void (^)(NSError *error))errorBlock;
 
 -(void)ewsHttpRequest:(NSString *)soapXmlString
                   url:(NSString *)url

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.h
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.h
@@ -25,12 +25,18 @@
 #import <Foundation/Foundation.h>
 #import "EWSEmailBoxModel.h"
 
-@interface EWSHttpRequest : NSObject
+typedef void(^HTTPRequestSuccessCompletion)(NSString *redirectLocation, NSData *xmlData);
+typedef void(^HTTPRequestFailureCompletion)(NSError *error);
 
-@property (nonatomic, strong) EWSEmailBoxModel *emailBoxModel;
+@interface EWSHttpRequest : NSObject
 
 -(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock;
 
 -(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock;
 
+-(void)ewsHttpRequest:(NSString *)soapXmlString
+                  url:(NSString *)url
+         emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo
+              success:(HTTPRequestSuccessCompletion)success
+              failure:(HTTPRequestFailureCompletion)failure;
 @end

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
@@ -23,90 +23,157 @@
 // SOFTWARE.
 
 #import "EWSHttpRequest.h"
+#import "EWSEmailBoxModel.h"
 
-typedef void  (^HttpRequestReceiveResponseBlock)(NSURLResponse *response);
-typedef void  (^HttpRequestErrorBlock)(NSError *error);
-typedef void  (^HttpRequestReceiveDataBlock)(NSData *data);
-typedef void  (^HttpRequestDidFinishLoadingBlock)();
+@interface EWSHttpRequest () <NSURLSessionDelegate>
 
-@implementation EWSHttpRequest{
-    HttpRequestReceiveResponseBlock _receiveResponseBlock;
-    HttpRequestReceiveDataBlock _receiveDataBlock;
-    HttpRequestDidFinishLoadingBlock _finishLoadingBlock;
-    HttpRequestErrorBlock _errorBlock;
-}
+@property (strong, nonatomic) NSMutableData *data;
+@property (strong, nonatomic) NSString *redirectLocation;
+@property (strong, nonatomic) EWSEmailBoxModel *emailBoxModel;
+@property (copy, nonatomic) HTTPRequestSuccessCompletion successBlock;
+@property (copy, nonatomic) HTTPRequestFailureCompletion failureBlock;
+
+@end
 
 
--(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
-    
+@implementation EWSHttpRequest
+
+- (void)ewsHttpRequest:(NSString *)soapXmlString url:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo success:(HTTPRequestSuccessCompletion)success failure:(HTTPRequestFailureCompletion)failure
+{
     self.emailBoxModel = emailBoxInfo;
-    [self ewsHttpRequest:soapXmlString andUrl:url receiveResponse:receiveResponseBlock reveiveData:receiveDataBlock finishLoading:finishLoadingBlock error:errorBlock];
-    
-}
 
--(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
-    
-    [self httpRequest:soapXmlString andUrl:url];
-    
-    _receiveResponseBlock = [receiveResponseBlock copy];
-    _receiveDataBlock = [receiveDataBlock copy];
-    _finishLoadingBlock = [finishLoadingBlock copy];
-    _errorBlock = [errorBlock copy];
-}
+    self.successBlock = success;
+    self.failureBlock = failure;
+    self.data = [NSMutableData data];
 
-
-
-
--(void)httpRequest:(NSString *)soapXmlString andUrl:(NSString *)url{
-    NSString *xmlLength = [NSString stringWithFormat:@"%ld",soapXmlString.length];
-    
     NSURL *requestUrl = [NSURL URLWithString:url];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestUrl];
-    [request addValue:@"text/xml; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
-    [request addValue: xmlLength forHTTPHeaderField:@"Content-Length"];
-    [request setHTTPMethod:@"POST"];
-    [request setHTTPBody:[soapXmlString dataUsingEncoding:NSUTF8StringEncoding]];
-    NSURLConnection *conn = [[NSURLConnection alloc] initWithRequest:request delegate:self];
-    if (conn == nil) {
-        NSLog(@"NSURLConnection init error!");
+    request.HTTPMethod = @"POST";
+
+    if (soapXmlString)
+    {
+        NSString *xmlLength = [NSString stringWithFormat:@"%ld", (unsigned long)soapXmlString.length];
+        request.HTTPBody = [soapXmlString dataUsingEncoding:NSUTF8StringEncoding];
+        [request addValue:@"text/xml; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
+        [request addValue:xmlLength forHTTPHeaderField:@"Content-Length"];
     }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        NSURLSessionConfiguration *defaultConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+
+        NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration:defaultConfiguration
+                                                                     delegate:self
+                                                                delegateQueue:nil];
+
+        NSURLSessionDataTask *dataTask = [defaultSession dataTaskWithRequest:request];
+
+        [dataTask resume];
+    });
 }
 
+//-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
+//
+//    self.emailBoxModel = emailBoxInfo;
+//    [self ewsHttpRequest:soapXmlString andUrl:url receiveResponse:receiveResponseBlock reveiveData:receiveDataBlock finishLoading:finishLoadingBlock error:errorBlock];
+//
+//}
+//
+//-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
+//
+//    [self httpRequest:soapXmlString andUrl:url];
+//
+//    _receiveResponseBlock = [receiveResponseBlock copy];
+//    _receiveDataBlock = [receiveDataBlock copy];
+//    _finishLoadingBlock = [finishLoadingBlock copy];
+//    _errorBlock = [errorBlock copy];
+//}
 
-#pragma mark - delegate
--(void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge{
-    
-    if ([challenge previousFailureCount]) {
-        
-        [[challenge sender] cancelAuthenticationChallenge:challenge];
-    }
-    else {
+#pragma mark - NSURLSession Delegates
 
-        NSURLCredential *credential = [NSURLCredential credentialWithUser:self.emailBoxModel.emailAddress
-                                                                 password:self.emailBoxModel.password
-                                                              persistence:NSURLCredentialPersistenceForSession];
+-(void)URLSession:(NSURLSession *)session
+             task:(NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+
+    if (challenge.previousFailureCount == 0)
+    {
+        NSURLCredential* credential;
+
+        credential = [NSURLCredential credentialWithUser:self.emailBoxModel.emailAddress password:self.emailBoxModel.password persistence:NSURLCredentialPersistenceForSession];
+
         [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+
+        completionHandler(NSURLSessionAuthChallengeUseCredential,credential);
+    }
+    else
+    {
+        // URLSession:task:didCompleteWithError delegate would be called as we are cancelling the request, due to wrong credentials.
+
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+    }
+
+}
+
+-(void)URLSession:(NSURLSession *)session
+         dataTask:(NSURLSessionDataTask *)dataTask
+didReceiveResponse:(NSURLResponse *)response
+completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+-(void)URLSession:(NSURLSession *)session
+         dataTask:(NSURLSessionDataTask *)dataTask
+   didReceiveData:(NSData *)data
+{
+
+    [self.data appendData:data];
+}
+
+-(void)URLSession:(NSURLSession *)session
+             task:(NSURLSessionTask *)task
+didCompleteWithError:(NSError *)error
+{
+    if (error)
+    {
+        self.failureBlock ? self.failureBlock(error) : nil; // FIXME: remove this line after shifting all network in queue
+
+    }
+    else
+    {
+        NSData *data;
+
+        if (self.data)
+        {
+            data = [NSData dataWithData:self.data];
+        }
+
+        self.successBlock ? self.successBlock(self.redirectLocation, data) : nil;
+    }
+
+    [session finishTasksAndInvalidate]; // We must release the session, else it holds strong referance for it's delegate (in our case EWSHTTPRequest).
+    // And it wont allow the delegate object to free -> cause memory leak
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+        newRequest:(NSURLRequest *)request
+ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler;
+
+{
+
+    self.redirectLocation = request.URL.absoluteString;
+
+    if (response)
+    {
+        completionHandler(nil);
+    }
+    else
+    {
+        completionHandler(request); // new redirect request
     }
 }
-
--(void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response{
-    
-    _receiveResponseBlock(response);
-}
-
--(void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data{
-    
-    _receiveDataBlock(data);
-}
-
--(void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error{
-    
-    _errorBlock(error);
-}
-
--(void)connectionDidFinishLoading:(NSURLConnection *)connection{
-    
-    _finishLoadingBlock();
-}
-
 @end

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
@@ -49,6 +49,7 @@
     NSURL *requestUrl = [NSURL URLWithString:url];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestUrl];
     request.HTTPMethod = @"POST";
+    request.timeoutInterval = 20.0;
 
     if (soapXmlString)
     {

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSHttpRequest.m
@@ -73,22 +73,21 @@
     });
 }
 
-//-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
-//
-//    self.emailBoxModel = emailBoxInfo;
-//    [self ewsHttpRequest:soapXmlString andUrl:url receiveResponse:receiveResponseBlock reveiveData:receiveDataBlock finishLoading:finishLoadingBlock error:errorBlock];
-//
-//}
-//
-//-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock reveiveData:(void (^)(NSData *data))receiveDataBlock finishLoading:(void (^)())finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
-//
-//    [self httpRequest:soapXmlString andUrl:url];
-//
-//    _receiveResponseBlock = [receiveResponseBlock copy];
-//    _receiveDataBlock = [receiveDataBlock copy];
-//    _finishLoadingBlock = [finishLoadingBlock copy];
-//    _errorBlock = [errorBlock copy];
-//}
+-(void)ewsHttpRequest:(NSString *)soapXmlString andUrl:(NSString *)url emailBoxInfo:(EWSEmailBoxModel *)emailBoxInfo receiveResponse:(void (^)(NSURLResponse *response))receiveResponseBlock finishLoading:(void (^)(NSData *data))finishLoadingBlock error:(void (^)(NSError *error))errorBlock{
+
+    [self ewsHttpRequest:soapXmlString url:url emailBoxInfo:emailBoxInfo success:^(NSString *redirectLocation, NSData *xmlData) {
+
+        NSString *xmlString = [[NSString alloc] initWithData:xmlData encoding:NSUTF8StringEncoding];
+
+        NSLog(@"xmlString Data: %@", xmlString);
+        finishLoadingBlock(xmlData);
+
+    } failure:^(NSError *error) {
+
+        errorBlock(error);
+    }];
+
+}
 
 #pragma mark - NSURLSession Delegates
 
@@ -110,7 +109,7 @@ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredentia
     }
     else
     {
-        // URLSession:task:didCompleteWithError delegate would be called as we are cancelling the request, due to wrong credentials.
+        // URLSession:task:didCompleteWithError in case of wrong credentials.
 
         completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
     }
@@ -139,7 +138,7 @@ didCompleteWithError:(NSError *)error
 {
     if (error)
     {
-        self.failureBlock ? self.failureBlock(error) : nil; // FIXME: remove this line after shifting all network in queue
+        self.failureBlock ? self.failureBlock(error) : nil;
 
     }
     else
@@ -154,7 +153,7 @@ didCompleteWithError:(NSError *)error
         self.successBlock ? self.successBlock(self.redirectLocation, data) : nil;
     }
 
-    [session finishTasksAndInvalidate]; // We must release the session, else it holds strong referance for it's delegate (in our case EWSHTTPRequest).
+    [session finishTasksAndInvalidate]; // release the session, else it holds strong referance for it's delegate (in our case EWSHTTPRequest).
     // And it wont allow the delegate object to free -> cause memory leak
 }
 

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSInboxList.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSInboxList.m
@@ -81,16 +81,16 @@ typedef void (^GetInboxListBlock)(NSMutableArray *inboxList, NSError *error);
     "</FindItem>\n"
     "</soap:Body>\n"
     "</soap:Envelope>\n";
-    
-    [request ewsHttpRequest:soapXmlString andUrl:url emailBoxInfo:((EWSManager *)[EWSManager sharedEwsManager]).ewsEmailBoxModel receiveResponse:^(NSURLResponse *response) {
-//        NSLog(@"response:%@",response);
-    } reveiveData:^(NSData *data) {
-        [eData appendData:data];
-    } finishLoading:^{
-//        NSLog(@"data:%@",[[NSString alloc] initWithData:eData encoding:NSUTF8StringEncoding]);
-//        NSLog(@"---inboxList---finish-------");
+
+    [request ewsHttpRequest:soapXmlString url:url emailBoxInfo:((EWSManager *)[EWSManager sharedEwsManager]).ewsEmailBoxModel success:^(NSString *redirectLocation, NSData *xmlData) {
+
+        //        NSLog(@"data:%@",[[NSString alloc] initWithData:xmlData encoding:NSUTF8StringEncoding]);
+        //        NSLog(@"---inboxList---finish-------");
+
+        [eData appendData:xmlData];
         [self requestFinishLoading];
-    } error:^(NSError *error) {
+
+    } failure:^(NSError *error) {
         _error = error;
     }];
 }

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSItemContent.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSItemContent.m
@@ -25,7 +25,7 @@
 #import "EWSItemContent.h"
 #import "EWSHttpRequest.h"
 #import "EWSXmlParser.h"
-
+#import "EWSManager.h"
 typedef void (^GetItemContentBlock)(EWSItemContentModel *itemContentInfo, NSError *error);
 
 @implementation EWSItemContent{
@@ -86,17 +86,18 @@ typedef void (^GetItemContentBlock)(EWSItemContentModel *itemContentInfo, NSErro
                                "</GetItem>\n"
                                "</soap:Body>\n"
                                "</soap:Envelope>\n",item.itemId,item.changeKey];
-    
-    [request ewsHttpRequest:soapXmlString andUrl:url receiveResponse:^(NSURLResponse *response) {
-//        NSLog(@"response:%@",response);
-    } reveiveData:^(NSData *data) {
-        [eData appendData:data];
-    } finishLoading:^{
-//        NSLog(@"data:%@",[[NSString alloc] initWithData:eData encoding:NSUTF8StringEncoding]);
-//        NSLog(@"----itemContent--finish-------");
+
+    [request ewsHttpRequest:soapXmlString url:url emailBoxInfo:((EWSManager *)[EWSManager sharedEwsManager]).ewsEmailBoxModel success:^(NSString *redirectLocation, NSData *xmlData) {
+
+        //        NSLog(@"----itemContent--finish-------");
+        //        NSLog(@"data:%@",[[NSString alloc] initWithData:eData encoding:NSUTF8StringEncoding]);
+
+        [eData appendData:xmlData];
         [self requestFinishLoading];
-    } error:^(NSError *error) {
+
+    } failure:^(NSError *error) {
         _error = error;
+
     }];
 }
 

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSMailAttachment.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSMailAttachment.m
@@ -25,6 +25,7 @@
 #import "EWSMailAttachment.h"
 #import "EWSHttpRequest.h"
 #import "EWSXmlParser.h"
+#import "EWSManager.h"
 
 typedef void (^GetAttachmentCompleteBlock)();
 
@@ -77,16 +78,15 @@ typedef void (^GetAttachmentCompleteBlock)();
                                "</GetAttachment>\n"
                                "</soap:Body>\n"
                                "</soap:Envelope>\n",attachmentInfo.attachmentId];
-    
-    [request ewsHttpRequest:soapXmlString andUrl:url receiveResponse:^(NSURLResponse *response) {
-        NSLog(@"response:%@",response);
-    } reveiveData:^(NSData *data) {
+
+    [request ewsHttpRequest:soapXmlString url:url emailBoxInfo:((EWSManager *)[EWSManager sharedEwsManager]).ewsEmailBoxModel success:^(NSString *redirectLocation, NSData *data) {
+
         [eData appendData:data];
-    } finishLoading:^{
-//        NSLog(@"data:%@",[[NSString alloc] initWithData:eData encoding:NSUTF8StringEncoding]);
+        //        NSLog(@"data:%@",[[NSString alloc] initWithData:eData encoding:NSUTF8StringEncoding]);
         NSLog(@"---attachment---finish-------");
         [self requestFinishLoading];
-    } error:^(NSError *error) {
+
+    } failure:^(NSError *error) {
         NSLog(@"error:%@",error);
     }];
 }

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.h
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.h
@@ -41,8 +41,14 @@
  *  @param description       邮箱描述
  *  @param mailServerAddress 邮箱服务器地址（如果没有设置就会用autodiscover去尝试寻找）
  *  @param domain            域
+ *  @param completion        completionHandles, returns true, if everything went well
  */
--(void)setEmailBoxInfoEmailAddress:(NSString *)emailAddress password:(NSString *)password description:(NSString *)description mailServerAddress:(NSString *)mailServerAddress domain:(NSString *)domain;
+-(void)setEmailBoxInfoEmailAddress:(NSString *)emailAddress
+                          password:(NSString *)password
+                       description:(NSString *)description
+                 mailServerAddress:(NSString *)mailServerAddress
+                            domain:(NSString *)domain
+                        completion:(void(^)(BOOL success))completion;
 
 /**
  *  获取邮箱列表

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.m
@@ -89,6 +89,7 @@ typedef void (^ManagerGetAttachmentCompleteBlock)();
         if (error) {
             NSLog(@"error:%@",error);
         }
+        NSLog(@"EWSUrl: %@", ewsUrl);
         ewsEmailBoxModel.mailServerAddress = ewsUrl;
     }];
 }

--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSManager.m
@@ -67,7 +67,12 @@ typedef void (^ManagerGetAttachmentCompleteBlock)();
     return instance;
 }
 
--(void)setEmailBoxInfoEmailAddress:(NSString *)emailAddress password:(NSString *)password description:(NSString *)description mailServerAddress:(NSString *)mailServerAddress domain:(NSString *)domain{
+-(void)setEmailBoxInfoEmailAddress:(NSString *)emailAddress
+                          password:(NSString *)password
+                       description:(NSString *)description
+                 mailServerAddress:(NSString *)mailServerAddress
+                            domain:(NSString *)domain
+                        completion:(void(^)(BOOL success))completion {
     ewsEmailBoxModel = [[EWSEmailBoxModel alloc] init];
     ewsEmailBoxModel.emailAddress = emailAddress;
     ewsEmailBoxModel.password = password;
@@ -77,20 +82,25 @@ typedef void (^ManagerGetAttachmentCompleteBlock)();
     
     if (!(ewsEmailBoxModel.emailAddress&&ewsEmailBoxModel.password)) {
         NSLog(@"emailAddress and password can't be nil");
+        completion(false);
     }
     else if (!ewsEmailBoxModel.mailServerAddress||[ewsEmailBoxModel.mailServerAddress isEqualToString:@""]) {
-        [self autodiscover];
+        [self autodiscoverWithCompletion:completion];
     }
     
 }
 
--(void)autodiscover{
+-(void)autodiscoverWithCompletion:(void(^)(BOOL success))completion {
+
     [[[EWSAutodiscover alloc] init] autoDiscoverWithEmailAddress:ewsEmailBoxModel.emailAddress finishBlock:^(NSString *ewsUrl, NSError *error) {
         if (error) {
             NSLog(@"error:%@",error);
+            completion(false);
+            return;
         }
         NSLog(@"EWSUrl: %@", ewsUrl);
         ewsEmailBoxModel.mailServerAddress = ewsUrl;
+        completion(true);
     }];
 }
 

--- a/EWS-For-iOS/EWS-For-iOS/ViewController.m
+++ b/EWS-For-iOS/EWS-For-iOS/ViewController.m
@@ -96,13 +96,21 @@
 -(void)confirmBtnClicked{
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
     
-    [[EWSManager sharedEwsManager] setEmailBoxInfoEmailAddress:_eAddressTf.text password:_ePasswordTf.text description:_eDescription.text mailServerAddress:_eServerAddress.text domain:nil];
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [self getAllItem];
-//        [self getInboxList];
-        
-    });
+    [[EWSManager sharedEwsManager] setEmailBoxInfoEmailAddress:_eAddressTf.text password:_ePasswordTf.text description:_eDescription.text mailServerAddress:_eServerAddress.text domain:nil completion:^(BOOL success) {
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            if (success) {
+
+                [self getAllItem];
+                //        [self getInboxList];
+            }
+            else {
+                NSLog(@"Something went wrong...May be EWS url was not discovered");
+            }
+        });
+
+    }];
 }
 
 -(void)getInboxList{


### PR DESCRIPTION
Hi,

As the library is outdated, I am trying to update it. Please review and let me know if any other changes are needed.

Changes are as follows: 
1. EWS somehow started to redirect the HTTP requests, App was not able to handle the redirection of HTTP request. I changed the code so now app is able to auto-discover ewsurl if EWS redirects the request.

2. The EWS needs user credentials in some cases which were not required or being sent, previously, i.e. when fetching the email content or attachments, due to which it was not fetching the content, It is also fixed now.

3. The app was using old deprecated `NSURLConnection` API, it is changed with new API `NSURLSession` 

The library seems to be fully functional now. 
