### PR TITLE
Try http url to autodiscover EWS endpoint URL

### DIFF
--- a/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSAutodiscover.m
+++ b/EWS-For-iOS/EWS-For-iOS/EWSManager/EWSAutodiscover.m
@@ -58,6 +58,7 @@ typedef void (^GetEWSUrlBlock)(NSString *ewsUrl, NSError *error);
         [autodiscoverAddressList addObject:[NSString stringWithFormat:@"https://autodiscover.%@/autodiscover/autodiscover.xml",[address objectAtIndex:1]]];
         [autodiscoverAddressList addObject:[NSString stringWithFormat:@"https://%@/autodiscover/autodiscover.xml",[address objectAtIndex:1]]];
         [autodiscoverAddressList addObject:[NSString stringWithFormat:@"https://email.%@/autodiscover/autodiscover.xml",[address objectAtIndex:1]]];
+        [autodiscoverAddressList addObject:[NSString stringWithFormat:@"http://autodiscover.%@/autodiscover/autodiscover.xml", [address objectAtIndex:1]]];
 
     }
     else{


### PR DESCRIPTION
In case of office 365 accounts sometimes https
urls are not able to find the Ews endpoint url via autodiscovery
As of now currently added http url is able to
autodiscover office 365 exchange account's EWS
endpoint url.

Fixes #5